### PR TITLE
#61 Kubernetes version check doesn't work on some versions (example: …

### DIFF
--- a/charts/inadyn/Chart.yaml
+++ b/charts/inadyn/Chart.yaml
@@ -3,7 +3,7 @@ name: inadyn
 description: A Helm chart for inadyn, a small and simple Dynamic DNS client with HTTPS support
 type: application
 version: 1.1.0
-kubeVersion: ^1.23.0
+kubeVersion: ">=1.23.0-0"
 appVersion: v2.10.0
 sources:
   - https://github.com/philippwaller/helm-charts/tree/main/charts/inadyn


### PR DESCRIPTION
…k3s)

Change the kubeversion value for kubernetes version compatibility (especially k3s)