### PR TITLE
feat(inadyn): allow disabling mounting of service account token

### DIFF
--- a/charts/inadyn/README.md
+++ b/charts/inadyn/README.md
@@ -65,11 +65,12 @@ This chart bootstraps an [Inadyn](https://github.com/troglobit/inadyn) deploymen
 
 ### Service Account
 
-| Name                         | Description                                           | Value  |
-| ---------------------------- | ----------------------------------------------------- | ------ |
-| `serviceAccount.create`      | Specifies whether a service account should be created | `true` |
-| `serviceAccount.annotations` | Annotations to add to the service account             | `{}`   |
-| `serviceAccount.name`        | The name of the service account to use.               | `""`   |
+| Name                         | Description                                                   | Value  |
+| ---------------------------- | ------------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Specifies whether a service account should be created         | `true` |
+| `serviceAccount.mount`       | Specifies whether the service account token should be mounted | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account                     | `{}`   |
+| `serviceAccount.name`        | The name of the service account to use.                       | `""`   |
 
 
 ## Support this project

--- a/charts/inadyn/templates/deployment.yaml
+++ b/charts/inadyn/templates/deployment.yaml
@@ -22,7 +22,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.mount }}
       serviceAccountName: {{ include "inadyn.serviceAccountName" . }}
+      {{- else  }}
+      automountServiceAccountToken: false
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:

--- a/charts/inadyn/values.yaml
+++ b/charts/inadyn/values.yaml
@@ -83,9 +83,11 @@ affinity: {}
 ##
 
 ## @param serviceAccount.create Specifies whether a service account should be created
+## @param serviceAccount.mount Specifies whether the service account token should be mounted
 ## @param serviceAccount.annotations Annotations to add to the service account
 ## @param serviceAccount.name The name of the service account to use.
 serviceAccount:
   create: true
+  mount: true
   annotations: {}
   name: ""


### PR DESCRIPTION
Add Helm value `serviceAccount.mount` (default: `true`), when set to `false`, it sets `automountServiceAccountToken` to `false` on the "inadyn" deployment.

I'm open to suggestions to another name or a different way of specifying this, but the point is, I don't need a service account for inadyn and I'd like to be able to somehow disable mounting the token.

Currently I can do that with a Helm post-render patch but I'd rather not have to.